### PR TITLE
Fix literal string matching

### DIFF
--- a/wsend
+++ b/wsend
@@ -375,11 +375,11 @@ if [ -e "$HOME/.wsend/.id" ]; then
   id=$(cat $HOME/.wsend/.id)
   #ask server for account type
   user_type=$(curl -s -F "uid=$id" $host/usertype)
-  if [ $user_type == 'free' ]; then
+  if [ "$user_type" == 'free' ]; then
     freeInfoMessage
-  elif [ $user_type == 'unregistered' ]; then
+  elif [ "$user_type" == 'unregistered' ]; then
     registerInfoMessage
-  elif [ $user_type == 'unknown' ]; then
+  elif [ "$user_type" == 'unknown' ]; then
     unregisteredSignUp
   fi
 else


### PR DESCRIPTION
Don't know from what changes it comes, but when coming back on master branch, each upload with accountype="" throw 3 errors : "Unary operator expected"

It comes from the bad quoting during comparisons, but I don't know why I don't see it earlier.(maybe changes on server side?)
